### PR TITLE
Assorted clarifications

### DIFF
--- a/waict-integrity.md
+++ b/waict-integrity.md
@@ -71,7 +71,7 @@ Integrity-Policy-Report-Only:
   endpoints: [string]
 ```
 
-We add one field, `hash-endpoints`, to this structure, with the default value of an empty list. In the header, the presentation format of this field is an inner list, similar to the other fields. This endpoint is where hash matching errors are sent. The endpoints are defined in the `Reporting-Endpoints` header in the same response.
+We add one boolean field, `hash-report-mode-enabled`, to this structure, with the default value of false. This flag is necessary to enable `hash-report` mode, described below.
 
 # Enforcement Algorithms
 
@@ -167,7 +167,7 @@ WAICT has two hash matching enforcement modes:
 * `hash-strict` : A subresource whose hash did not match the expected one will not be loaded/unlocked into the page
 * `hash-report` : A subresource whose hash did not match the expected one will loaded and notifications will be only sent to developers, similar to `report-uri`
 
-Enforcement modes on a server's response are dictated by the contents of the response's headers. Specifically, `hash-report` mode is enabled if `Integrity-Policy` has empty `blocked-destinations`, and `Integrity-Policy-Report-Only` has a nonempty `hash-endpoints`. Otherwise, `hash-strict` mode is enabled.
+Enforcement modes on a server's response are dictated by the contents of the response's headers. Specifically, `hash-report` mode is enabled if `Integrity-Policy` has empty `blocked-destinations`, and `Integrity-Policy-Report-Only` has `hash-report-mode-enabled` set to true. Otherwise, `hash-strict` mode is enabled.
 
 (TODO: Describe the structure of the hash match failure reports)
 


### PR DESCRIPTION
Makes the edits proposed in #1. Two things worth highlighting:

# Reporting hash match failures

SRI currently does NOT let a server opt out of hash checking. If a hash is specified, it is checked, and on failure, it halts loading the resource. This PR suggests a loosening of this via a `hash-endpoints` in `Integrity-Policy-Report-Only`. When this is enabled, and no `blocked-destinations` are present in the `Integrity-Policy` header, then all hash check failures become mere reports.

# Allowed-anywhere hashes imply integrity checking everywhere

Blocked destinations interacts weirdly with allowed-anywhere hashes. With existing SRI, if an inline hash is present for a subresource it is _always_ checked. If a destination is not blocked, and the subresource is missing a hash, then nothing is checked and everything is fine.

In manifest world, this is harder. If there are allowed-anywhere hashes in the manifest, then they _may or may not_ apply to the subresource being fetched. To break the tie, I decided that they _always do_ apply to the resource. That is, **if allowed-anywhere hashes are specified, then every subresource gets put through an integrity check.** If you want to disable this, you can set `hash-endpoints` to make errors report-only.

I thought this is an okay choice because very few people are going to use allowed-anywhere hashes. The other, more common, cases are normal. Eg if you don't have scripts as a blocked destination and don't have allowed-anywhere hashes, and you fetch a script and its path is missing in the manifest, then the script is loaded no problem.

---

I added a few TODOs here as well, which I think I can get to in future PRs. I'll also do some cleanup tomorrow, but I figured putting this up in its near-final state would be helpful to start an initial review.