### PR TITLE
Add escape hatch to disable transparency

### DIFF
--- a/waict-integrity.md
+++ b/waict-integrity.md
@@ -193,7 +193,7 @@ Manifests MUST have the following properties:
 * All mandatory keys are present.
 * Values in `hashes` and `wildcard_hashes` are valid base64 ([RFC 4648 Section 4](https://www.rfc-editor.org/rfc/rfc4648#section-4)) and decode to exactly 32 bytes.
 * Each key `s` of `hashes` is a _canonical_ URL, defined as follows. `s` is parsed with the [API URL Parser](https://url.spec.whatwg.org/#api-url-parser) using the top-level origin (serialized as `scheme://host:port/`) as base URL (note, this permits external URLs; the base is only applied when the provided URL is relative), and any [fragment](https://url.spec.whatwg.org/#concept-url-fragment) is removed. The result is then [URL-serialized](https://url.spec.whatwg.org/#concept-url-serializer) with the *exclude fragment* flag set. `s` is canonical when this serialization equals `s`.
-* If a proof of transparency was included with the manifest, or the manifest was linked to by a WAICT integrity policy header with nonzero `max-age` that is still in effect, then the transparency proof is successfully parsed and checked using the algorithm in TODO
+* If the manifest was linked to by a WAICT integrity policy header with nonzero `max-age` that is still in effect, then the transparency proof is successfully parsed and checked using the algorithm in TODO
 
 The last property above allows servers to effectively disable WAICT transparency by setting the policy's `max-age` to 0, and serving an empty string (or any other newline-free string) as the transparency proof.
 


### PR DESCRIPTION
As mentioned in #25 you can imagine scenarios where integrity is valuable but transparency is not. This PR
1. Clarifies that transparency is part of manifest validation (previously this was unclear)
2. Says that if you set WAICT `max-age=0`, the client will skip transparency parsing+checking

The `max-age=0` is particularly slick actually. Nonzero max age mean the server wants lasting enforcement, which is only meaningful if there is transparency. Also it means that if there is any existing manifest in effect, either via a nonzero `max-age` or via preload (which has `max-age` > 1 year), then you cannot disable transparency.

Closes #25, #26

cc @lsd-cat 