### PR TITLE
Add fallback_hashes to allow for server errors

### DIFF
--- a/waict-integrity.md
+++ b/waict-integrity.md
@@ -151,6 +151,7 @@ The integrity manifest is a JSON object with the following structure. All fields
 
 * `hashes` — a dictionary mapping URLs to hashes. All hashes MUST use the SHA-256 algorithm and be base64urlnopad-encoded.
 * `wasm_hashes` (optional) — a lexicographically sorted list of unique SHA-256 hashes (base64urlnopad) of permitted WebAssembly module bytes. The sorted order enables efficient membership testing by user-agents. See [Changes to WebAssembly Processing](#changes-to-webassembly-processing).
+* `fallback_hashes` (optional) - a lexicographically sorted list of unique SHA-256 hashes (base64urlnopad) of permitted content only for document navigation. The sorted order enables efficient membership testing by user-agents.
 * `wildcard_hashes` (optional) — a lexicographically sorted list of unique SHA-256 hashes (base64urlnopad-encoded). The sorted order enables efficient membership testing by user-agents.
 * `resource_delimiter` (optional) — a string used for splitting subresource contents.
 * `emergency_opt_out` (optional) — a boolean used when the origin needs to disable WAICT immediately. Default is `false`
@@ -172,6 +173,10 @@ An example is given below:
   "wasm_hashes": [
     "Aq3rP9FkR8vLHnUGT5OgP7xmNyvDh2YcfJLmzgSEz7o=",
     "kJ2E9N8C3vR5xP7yQwL4mFbA6dH0jT2uK9sG1nO3iVc="
+  ],
+  "fallback_hashes": [
+    "aB3xW9vKpL2mRnQy7dFtUeHsOiGjCzNw4kYuMlPqVrS=",
+    "tP8cE1hXwD5nJbAf6gQsIyKoZvLmRuN2eCdFpWxBqM0="
   ],
   "wildcard_hashes": [
     "mVuswfW4XCBOWbx+QiKkPPQy+gTfr+i1sVADexgyN+8=",
@@ -275,6 +280,8 @@ The response body is [fully read](https://fetch.spec.whatwg.org/#body-fully-read
 1. Let `b` be the bytes of the response body and `h` be the base64urlnopad-encoded SHA-256 hash of `b`.
 1. Let `pathHash` be the hash value from `manifest["hashes"]` whose key's canonical form (as defined in [Validating Manifests](#validating-manifests)) equals `reqKey`, or `undefined` if no such entry exists.
 1. If the destination type is listed under **passive content** and `pathHash` is undefined, return success.
+1. Let `fallbackHashes` be `manifest["fallback_hashes"]`, or undefined if not present.
+1. If `fallbackHashes` is defined and non-empty, and the request destination is `document`, check whether `h` is a member of `fallbackHashes`. If it is, return success.
 1. Let `wildcardHashes = manifest["wildcard_hashes"]`, or `undefined` if not present.
 1. If `pathHash` is defined, compare `h` to `pathHash`. If they match, return success. Otherwise, fail with reason `no_manifest_match`. A resource whose URL appears in `hashes` MUST match via its `pathHash`; the wildcard check is never used as a fallback.
 1. If `wildcardHashes` is defined and non-empty and `resource_delimiter` is defined and non-empty:


### PR DESCRIPTION
Tries to implement logic for https://github.com/waict-wg/waict-integrity-spec/issues/39

The goals are the following:
- Use a list of hashes as discussed
- Fallback on it only on main document navigation

Here's the rationale:

WAICT's threat model assumes an untrusted server. This means any signal the server sends, including HTTP status codes,  could be faked by a compromised server. The fallback mechanism must therefore be designed so that a compromised server cannot use it to bypass integrity checks.

Subresources (scripts, styles, workers, etc.) are never allowed to fall back for two reasons: first, a compromised server silently dropping or replacing a subresource with an error response is within the attacks we are trying to prevent. Second, subresource error responses are not user-visible, so there is no legitimate UX reason to allow them.

Document navigations are different. If a server is genuinely failing (e.g. a 404 for an unknown path, or a 500 due to any other error), the user should see a meaningful error page rather than a confusing browser-level integrity error. Since the error page is the entire document, and any subresources it loads are still subject to integrity checking, the security impact of allowing a pre-committed error page on document navigation should be limited.

The specific cases this enables are:
- _404 for unknown paths (or 403 for unlosted paths, etc)_: a URL that is not part of the web application at all can return a pre-committed error page.
- _500 or other server errors on the index or any navigable URL_: if the server is overloaded or otherwise failing, it can return a pre-committed error page instead of the expected document.

In both cases the error page body must match a hash in `fallback_hashes`, meaning the set of permitted error pages is publicly committed to in the manifest and subject to the same transparency guarantees as the rest of the application.