### PR TITLE
Stricter error pages

### DIFF
--- a/waict-integrity.md
+++ b/waict-integrity.md
@@ -291,9 +291,10 @@ The response body is [fully read](https://fetch.spec.whatwg.org/#body-fully-read
 1. Let `errorPageHashes` be `manifest["error_page_hashes"]`, or `undefined` if not present.
 1. If the request is a top-level HTML request, and the response status code is 400–599 (inclusive), check whether `h` is a member of `errorPageHashes` (returning `false` if `errorPageHashes` is undefined). If the membership check succeeded, return success. If a membership check was performed and returned false, fail with reason `no_manifest_match`.
 1. Let `wildcardHashes = manifest["wildcard_hashes"]`, or `undefined` if not present.
+1. Let `resourceDelimiter = manifest["resource_delimiter"]`, or `undefined` if not present.
 1. If `pathHash` is defined, compare `h` to `pathHash`. If they match, return success. Otherwise, fail with reason `no_manifest_match`. A resource whose URL appears in `hashes` MUST match via its `pathHash`; the wildcard check is never used as a fallback.
-1. If `wildcardHashes` is defined and non-empty and `resource_delimiter` is defined and non-empty:
-    1. Let `d` be `resource_delimiter`.
+1. If `wildcardHashes` is defined and non-empty and `resourceDelimiter` is defined and non-empty:
+    1. Let `d` be `resourceDelimiter`.
     1. For each component `b_i` of `b`, compute `SHA-256(b_i)`, base64urlnopad-encode it, and check whether the result is a member of `wildcardHashes`. If all components match, return success. Otherwise, fail with reason `no_manifest_match`.
 1. Fail with reason `missing_from_manifest`.
 

--- a/waict-integrity.md
+++ b/waict-integrity.md
@@ -289,7 +289,7 @@ The response body is [fully read](https://fetch.spec.whatwg.org/#body-fully-read
 1. Let `pathHash` be the hash value from `manifest["hashes"]` whose key's canonical form (as defined in [Validating Manifests](#validating-manifests)) equals `reqKey`, or `undefined` if no such entry exists.
 1. If the destination type is listed under **passive content** and `pathHash` is undefined, return success.
 1. Let `errorPageHashes` be `manifest["error_page_hashes"]`, or `undefined` if not present.
-1. If the request is a top-level HTML request, and the response status code is 400–599 (inclusive), check whether `h` is a member of `errorPageHashes` (returning `false` if `errorPageHashes` is undefined). If the membership check succeeded, return success. If a membership check was performed and returned false, fail with reason `no_manifest_match`.
+1. If the request destination is `document`, and the response status code is 400–599 (inclusive), check whether `h` is a member of `errorPageHashes` (returning `false` if `errorPageHashes` is undefined). If the membership check succeeded, return success. If a membership check was performed and returned false, fail with reason `no_manifest_match`.
 1. Let `wildcardHashes = manifest["wildcard_hashes"]`, or `undefined` if not present.
 1. Let `resourceDelimiter = manifest["resource_delimiter"]`, or `undefined` if not present.
 1. If `pathHash` is defined, compare `h` to `pathHash`. If they match, return success. Otherwise, fail with reason `no_manifest_match`. A resource whose URL appears in `hashes` MUST match via its `pathHash`; the wildcard check is never used as a fallback.

--- a/waict-integrity.md
+++ b/waict-integrity.md
@@ -159,8 +159,8 @@ The integrity manifest is a JSON object with the following structure. All fields
 
 * `hashes` — a dictionary mapping URLs to hashes. All hashes MUST use the SHA-256 algorithm and be base64urlnopad-encoded.
 * `wasm_hashes` (optional) — a lexicographically sorted list of unique SHA-256 hashes (base64urlnopad) of permitted WebAssembly module bytes. The sorted order enables efficient membership testing by user-agents. See [Changes to WebAssembly Processing](#changes-to-webassembly-processing).
-* `fallback_hashes` (optional) - a lexicographically sorted list of unique SHA-256 hashes (base64urlnopad) of permitted content only for document navigation. The sorted order enables efficient membership testing by user-agents.
-* `wildcard_hashes` (optional) — a lexicographically sorted list of unique SHA-256 hashes (base64urlnopad-encoded). The sorted order enables efficient membership testing by user-agents.
+* `error_page_hashes` (optional) - a lexicographically sorted list of unique SHA-256 hashes (base64urlnopad) of permitted content only for document navigation. Each entry is an error page that the server is permitted to serve when it returns a 4xx or 5xx error.
+* `wildcard_hashes` (optional) — a lexicographically sorted list of unique SHA-256 hashes (base64urlnopad-encoded).
 * `resource_delimiter` (optional) — a string used for splitting subresource contents.
 * `emergency_opt_out` (optional) — a boolean used when the origin needs to disable WAICT immediately. Default is `false`
 
@@ -182,7 +182,7 @@ An example is given below:
     "Aq3rP9FkR8vLHnUGT5OgP7xmNyvDh2YcfJLmzgSEz7o=",
     "kJ2E9N8C3vR5xP7yQwL4mFbA6dH0jT2uK9sG1nO3iVc="
   ],
-  "fallback_hashes": [
+  "error_page_hashes": [
     "aB3xW9vKpL2mRnQy7dFtUeHsOiGjCzNw4kYuMlPqVrS=",
     "tP8cE1hXwD5nJbAf6gQsIyKoZvLmRuN2eCdFpWxBqM0="
   ],
@@ -288,8 +288,8 @@ The response body is [fully read](https://fetch.spec.whatwg.org/#body-fully-read
 1. Let `b` be the bytes of the response body and `h` be the base64urlnopad-encoded SHA-256 hash of `b`.
 1. Let `pathHash` be the hash value from `manifest["hashes"]` whose key's canonical form (as defined in [Validating Manifests](#validating-manifests)) equals `reqKey`, or `undefined` if no such entry exists.
 1. If the destination type is listed under **passive content** and `pathHash` is undefined, return success.
-1. Let `fallbackHashes` be `manifest["fallback_hashes"]`, or undefined if not present.
-1. If `fallbackHashes` is defined and non-empty, and the request destination is `document`, check whether `h` is a member of `fallbackHashes`. If it is, return success.
+1. Let `errorPageHashes` be `manifest["error_page_hashes"]`, or `undefined` if not present.
+1. If the request is a top-level HTML request, and the response status code is 400–599 (inclusive), check whether `h` is a member of `errorPageHashes` (returning `false` if `errorPageHashes` is undefined). If the membership check succeeded, return success. If a membership check was performed and returned false, fail with reason `no_manifest_match`.
 1. Let `wildcardHashes = manifest["wildcard_hashes"]`, or `undefined` if not present.
 1. If `pathHash` is defined, compare `h` to `pathHash`. If they match, return success. Otherwise, fail with reason `no_manifest_match`. A resource whose URL appears in `hashes` MUST match via its `pathHash`; the wildcard check is never used as a fallback.
 1. If `wildcardHashes` is defined and non-empty and `resource_delimiter` is defined and non-empty:


### PR DESCRIPTION
I thought error pages (#50) were gonna be stricter actually. In my mind:
1. An error page can only be served when an error status code is present
2. An error page MUST be served when an error status code is present

This isn't a big deal but I think it makes sense. An error page without a 400–599 status code seems unlikely (and odd if it happens), and a 400–599 status code without an error page is _very_ odd

cc @lsd-cat @dennisjackson 