### PR TITLE
Rework integrity model around per-category modes and CSP reuse

### DIFF
--- a/waict-integrity.md
+++ b/waict-integrity.md
@@ -4,7 +4,7 @@ Web Application Integrity, Consistency, and Transparency (WAICT) enables website
 
 This enables third parties to inspect the web application served to user-agents and so mitigate the risk of a compromised website serving malicious code. This security guarantee is particularly important for threat models where the server is not trusted by the user-agent, for example, in End-to-End Encrypted messaging.
 
-WAICT's integrity model builds upon [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Subresource_Integrity) and the [Integrity-Policy header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Integrity-Policy). This document describes how WAICT is signalled by user-agents and websites and how the integrity of web applications is assured. The transparency of web applications is described in a separate specification.
+WAICT's integrity model builds upon [Subresource Integrity (SRI)](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Subresource_Integrity), [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) and the [Integrity-Policy header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Integrity-Policy). This document describes how WAICT is signalled by user-agents and websites and how the integrity of web applications is assured. The transparency of web applications is described in a separate specification.
 
 WAICT provides a stronger security property for user-agents, not servers, by making additional security checks on content fetched from the network. It does not constrain how user-agents locally modify pages, for example through user-agent preferences, extensions or other third-party additions.
 
@@ -21,7 +21,7 @@ Where this document refers to base64 encoding, it means the standard alphabet de
 
 # Negotiating WAICT Support
 
-User-agents SHOULD signal that they support WAICT to the server through the use of user-agent client hints. Doing so will allow the server to avoid sending unnecessary information to user-agents which don't support WAICT.
+User-agents SHOULD signal that they support WAICT to servers through the use of user-agent client hints. Doing so will allow servers to avoid sending unnecessary information to user-agents which don't support WAICT.
 
 To signal WAICT support, the [user agent client hint](https://wicg.github.io/ua-client-hints/) `Sec-CH-WAICT` is used whose value is a `sf-list` of `sf-integers`. Each integer represents a supported version of WAICT. This specification defines version `1`. If user-agents include a `Sec-CH-WAICT` header in their requests, the included version numbers MUST be supported by the user-agent.
 
@@ -41,25 +41,54 @@ Websites signal that they want user-agents to enforce WAICT through the use of t
 
 The header is a structured response header (Dictionary type per [RFC 9651](https://www.rfc-editor.org/rfc/rfc9651)). The following key-value pairs MUST be present:
 
-* `max-age` - An `sf-integer` that MUST be `>= 0`. How long (in seconds) user-agents MUST enforce WAICT after seeing this header (downgrade protection).
-* `mode` - An `sf-token` containing either `enforce` or `report`. In `enforce` mode, subresources that fail integrity checks are blocked from loading. In `report` mode, failures are reported but resources are still loaded.
+* `max-age` - An `sf-integer` that MUST be `>= 0`. How long (in seconds) user-agents MUST enforce WAICT after seeing this header (used for downgrade protection).
 * `manifest` - An `sf-string` containing a URL where the user-agent can fetch the WAICT manifest. The URL MAY be relative, in which case it is resolved against the origin's base URL.
 
-If one or more of the mandatory keys is missing or invalid, the entire header MUST be ignored.
+The data located at the `manifest` URL MUST be immutable, i.e., the unencoded response body of a successful GET request to that URL MUST never change. To achieve this, implementers SHOULD include a SHA-256 hash of the unencoded response body in the URL itself, encoded in base64url, and truncated to 22 characters (equivalent to base64urlnopad truncated to 22 characters; this encodes 128 bits).
+
+In addition, the header MUST contain at least one **category key**. Category keys are prefixed with `mode-` and indicate which classes of integrity check the user-agent should enforce for this origin, and at what strictness. Each category key has an `sf-token` value drawn from `enforce`, `warn`, or `report`:
+
+* `enforce` — failures of this category are blocked, surfaced through a network error or equivalent (see [Enforce Mode](#enforce-mode)).
+* `warn` — the operation is permitted to proceed, but the user-agent surfaces a user-visible warning if a check fails (see [Warn Mode](#warn-mode)).
+* `report` — the operation is permitted to proceed, and failures are reported only to developer-facing channels (see [Report Mode](#report-mode)).
+
+This specification defines the category keys listed in the table below. The **Destinations** column lists the [request destinations](https://fetch.spec.whatwg.org/#concept-request-destination) covered by each category, and is also used in reverse during [Determine Coverage](#determine-coverage) to map an outgoing request to its category. The active/passive classification is a fixed property of each category and governs how URLs missing from the manifest are handled (see [Integrity Check](#integrity-check)). Operators choose only the strictness level; they cannot change a category's class.
+
+Where a category corresponds to a CSP fetch directive, the category name is the singular form of the destination, matching CSP's `<thing>-src` convention.
+
+| Category key      | Destinations                                                                      | CSP analogue      | Class   |
+| ---               | ---                                                                               | ---               | ---     |
+| `mode-document`   | `document`                                                                        | —                 | active  |
+| `mode-frame`      | `frame`, `iframe`                                                                 | `frame-src`       | active  |
+| `mode-script`     | `script`, `xslt`                                                                  | `script-src`      | active  |
+| `mode-object`     | `object`                                                                          | `object-src`      | active  |
+| `mode-worker`     | `worker`, `serviceworker`, `sharedworker`, `audioworklet`, `paintworklet`         | `worker-src`      | active  |
+| `mode-style`      | `style`                                                                           | `style-src`       | active  |
+| `mode-image`      | `image`                                                                           | `img-src`         | passive |
+| `mode-font`       | `font`                                                                            | `font-src`        | passive |
+| `mode-media`      | `audio`, `video`                                                                  | `media-src`       | passive |
+
+In addition, WAICT defines three category keys that do not correspond to network fetch destinations and do not participate in the active/passive classification above. Their behavior is defined in the referenced sections:
+
+* `mode-wasm` — governs WebAssembly compilation. See [Changes to WebAssembly Processing](#changes-to-webassembly-processing).
+* `mode-inline-js` — governs inline scripts, inline event-handler attributes, dynamic code, and `javascript:` URIs. See [Inline Scripts, Styles, and Dynamic Code](#inline-scripts-styles-and-dynamic-code).
+* `mode-inline-css` — governs inline `<style>` elements and inline `style` attributes. See [Inline Scripts, Styles, and Dynamic Code](#inline-scripts-styles-and-dynamic-code).
+
+Category keys MUST appear at most once in the header (a property guaranteed by the structured-field Dictionary syntax). Category keys other than those described above MUST be ignored. A category key whose value is not one of `enforce`, `warn`, or `report` MUST be ignored.
+
+If `max-age` or `manifest` is missing or invalid, or if no recognized category key with a valid value is present, the entire header MUST be ignored.
 
 The following key-value pairs are optional:
 
 * `preload` - An `sf-boolean`. Indicates the site wants to enforce WAICT indefinitely (with transparency enabled) via a preload list. This field is not used directly by user-agents. `?0` (false) by default.
-* `endpoints` - Indicates endpoint(s) for submitting violations following [Integrity Policy Reporting](https://w3c.github.io/webappsec-subresource-integrity/#integrity-policy-section). Empty by default.
+* `report-to` - Indicates endpoint(s) for submitting violations following [Integrity Policy Reporting](https://w3c.github.io/webappsec-subresource-integrity/#integrity-policy-section). Empty by default. The key is named to parallel CSP's [`report-to` directive](https://www.w3.org/TR/CSP3/#directive-report-to).
 
-Any other keys MUST be ignored. Servers MAY set additional keys prefixed `GREASE-` which user-agents MUST ignore.
-
-The data located at the `manifest` URL MUST be immutable, i.e., the unencoded response body of a successful GET request to that URL MUST never change. To achieve this, implementers SHOULD include a SHA-256 hash of the unencoded response body in the URL itself, encoded in base64url, and truncated to 22 characters (equivalent to base64urlnopad truncated to 22 characters; this encodes 128 bits).
+Any other keys MUST be ignored.
 
 An example header is given below:
 
 ```HTTP
-Integrity-Policy-WAICT-v1: max-age=90, mode=report, preload=?0, endpoints=(foo-reports), manifest="/.well-known/waict/manifests/baz_manifest_5X_MjpjR0bpBpP3dEF6-hA"
+Integrity-Policy-WAICT-v1: max-age=90, mode-document=enforce, mode-frame=enforce, mode-script=enforce, mode-object=enforce, mode-worker=enforce, mode-style=warn, mode-image=report, mode-font=report, mode-media=report, mode-wasm=warn, mode-inline-js=report, mode-inline-css=report, preload=?0, report-to=(foo-reports), manifest="/.well-known/waict/manifests/baz_manifest_5X_MjpjR0bpBpP3dEF6-hA"
 ```
 
 Websites using WAICT MUST set a WAICT response header on top-level navigation responses. Websites MAY additionally set the header on subresource responses as a defence in depth measure against user-agents with stale manifests (see [Manifest Override on Subresource Responses](#manifest-override-on-subresource-responses)).
@@ -70,9 +99,7 @@ Websites using WAICT MUST set a WAICT response header on top-level navigation re
 
 WAICT state is scoped to the top-level origin and applies to requests made within the context of that origin. It does not extend to requests made by other top-level origins and so is compatible with the partitioning of state by top-level origin.
 
-When an origin is using WAICT, all requests made with a same site [top-level navigation initiator origin](https://fetch.spec.whatwg.org/#ref-for-request-top-level-navigation-initiator-origin) will be impacted by the WAICT security policy.
-
-When processing a response whose origin is the same site as the [top-level navigation initiator origin](https://fetch.spec.whatwg.org/#ref-for-request-top-level-navigation-initiator-origin), user-agents MUST check for valid `Integrity-Policy-WAICT-v1` response headers and SHOULD store the WAICT configuration for this origin for at most `max-age` seconds from the present. This information is partitioned to the top-level origin.
+When processing a response whose origin is the same as the [top-level navigation initiator origin](https://fetch.spec.whatwg.org/#ref-for-request-top-level-navigation-initiator-origin), user-agents MUST check for valid `Integrity-Policy-WAICT-v1` response headers and MUST store the WAICT configuration for this origin for at most `max-age` seconds from the present. This information is partitioned to the top-level origin.
 
 However, WAICT does not impact requests made to a WAICT-enforcing domain in other top-level contexts if those top-level contexts do not advertise WAICT themselves. User-agents MUST ignore `Integrity-Policy-WAICT-v1` headers set on responses whose origin does not match their current top-level navigation initiator origin. An example:
 
@@ -83,40 +110,41 @@ However, WAICT does not impact requests made to a WAICT-enforcing domain in othe
 
 When an `<iframe>` loads a document from the same origin as the top-level page, the iframe's document and all of its subresources are subject to the same WAICT integrity checks as the top-level page. When an `<iframe>` loads a document from a different origin, the iframe's own subresources are only subject to WAICT if that origin independently advertises WAICT.
 
-### Storage
-
-User-agents MUST store WAICT state for a top-level origin in order to prevent downgrade attacks. WAICT state is partitioned by top-level origin. For each top-level origin, the user-agent SHOULD store the record:
-
-* The list of reporting endpoints
-* The manifest URL
-* The mode (`enforce` or `report`)
-* The effective expiry time (`max-age` seconds from when the header was last seen)
-
-The user-agent MUST clear the state when it reaches its effective expiry time and MAY clear it sooner. There may be situations in which user-agents are unable to store the information described above. For example, user-agents may not have access to long-term state (e.g. they are running in a private browsing mode). Such user-agents SHOULD store the record for as long as they are able.
-
 ### Validating Existing Service Worker and Cache
 
-When a user-agent first observes a valid `Integrity-Policy-WAICT-v1` header for an origin (i.e., no prior WAICT state exists for that origin), or when it fetches a new manifest for an origin that differs from the previously stored manifest URL, the user-agent MUST trigger an update check for any Service Workers registered for the top-level origin. The user-agent MUST prevent any existing Service Worker from intercepting covered fetches until the update check has completed. If the updated Service Worker script passes the WAICT integrity check against the current manifest, the update MAY proceed to install and activate normally. If the integrity check fails, the update MUST be rejected following the failure handling described in [Handling Failures](#handling-failures), and the existing Service Worker MUST be unregistered.
+When a user-agent first observes a valid `Integrity-Policy-WAICT-v1` header for an origin (i.e., no prior WAICT state exists for that origin), or when it fetches a new manifest for an origin that differs from the previously stored manifest URL, the user-agent MUST trigger an update check for any Service Workers registered for the top-level origin. The user-agent MUST prevent any existing Service Worker from intercepting covered fetches until the update check has completed. If the updated Service Worker script passes the WAICT integrity check against the current manifest, the update MAY proceed to install and activate normally. If the integrity check fails, the update MUST follow the failure handling described in [Handling Failures](#handling-failures) for the appropriate mode.
 
-WAICT integrity checks apply to all covered responses regardless of whether they were served from the network or the HTTP cache. User-agents MUST NOT exempt cached responses from integrity checking.
+WAICT integrity checks apply to all covered responses regardless of whether they were served from the network or the HTTP cache. User-agents MUST NOT exempt cached responses from integrity checking. If a user-agent cannot apply checks to a cached resource because it no longer retains the necessary information (e.g. the user-agent has transformed the local representation resource and discarded the original representation) it should treat the resource as missing from the cache.
 
 ### Upgrades and Downgrades
 
-Origins may change their WAICT header over time. For example, an origin may evaluate WAICT in report mode and later switch to enforce mode. Alternatively, a site may be enforcing WAICT and wish to change the scope of covered resources, or even disable WAICT entirely. However, user-agents MUST enforce certain rules to prevent downgrade attacks - where a site alters its WAICT signalling in order to enable attacks.
+Origins may change their WAICT header over time. For example, an origin may evaluate the `mode-script` category in `report` mode and later switch to `enforce`. Alternatively, a site may be enforcing WAICT for one category and wish to add another, change the scope of covered resources, or disable a category entirely. However, user-agents MUST enforce certain rules to prevent downgrade attacks - where a site alters its WAICT signalling in order to enable attacks. Each category is ratcheted independently: upgrading one category is immediate, but downgrading or removing it requires waiting out that category's previously committed `max-age`.
 
-User-agents MUST follow this algorithm when updating their WAICT state:
+To prevent downgrade attacks, user-agents MUST store WAICT state for each top-level origin that has advertised WAICT, partitioned by top-level origin. The stored record is composed of:
 
-1. Overwrite the list of reporting endpoints with the latest contents of `endpoints`.
+* the list of reporting endpoints,
+* the manifest URL, and
+* for each category in use, a tuple `(mode, expiry)` where `mode` is one of `enforce`, `warn`, `report` and `expiry` is `max-age` seconds from when the header carrying that category was last seen.
+
+User-agents without access to long-term state (e.g. private browsing) SHOULD retain this record for as long as they are able. Modes are ordered by strictness as `report` < `warn` < `enforce`.
+
+User-agents MUST follow this algorithm when processing a valid `Integrity-Policy-WAICT-v1` header:
+
+1. Overwrite the list of reporting endpoints with the latest contents of `report-to`.
 2. Overwrite the manifest URL with the latest `manifest` entry.
-3. If there is no existing mode, store the new mode.
-4. Otherwise, if there is an existing mode, compare the existing and new mode:
-   1. If the new mode is `enforce` and the previous record was `report`, update the entry with the new mode and effective expiry, or
-   2. If the new mode has the same mode as the existing mode and the new effective expiry time is further in the future, update the effective expiry time.
-   3. Otherwise, ignore the new record.
+3. Let `new_expiry` be `max-age` seconds from the present.
+4. Construct the set of **effective category bindings** for this header as follows. Start with an empty map. For each recognized category listed in [Response Header](#response-header), if it is explicitly present in the header with a valid value, bind it to that value.
+5. For each (category, `new_mode`) pair in the effective category bindings:
+   1. If there is no existing record for this category, store (category, `new_mode`, `new_expiry`).
+   2. Otherwise, let (`existing_mode`, `existing_expiry`) be the existing record. Then:
+      1. If `new_mode` is strictly stronger than `existing_mode` under the ordering above, replace the existing record with (category, `new_mode`, `new_expiry`).
+      2. Otherwise, if `new_mode` equals `existing_mode` and `new_expiry` is further in the future than `existing_expiry`, replace `existing_expiry` with `new_expiry`.
+      3. Otherwise, ignore the update for this category.
+6. Existing records for categories not produced by step 4 are left unchanged and continue to age toward their previously committed expiry.
 
-Any record which has reached its effective expiry time MUST be ignored and SHOULD be removed.
+Any per-category record which has reached its effective expiry time MUST be ignored and SHOULD be removed.
 
-This algorithm ensures that sites can upgrade their WAICT coverage immediately. However, a site can only downgrade their WAICT coverage after `max-age` seconds pass since they last served a header.
+This algorithm ensures that sites can upgrade any category of WAICT coverage immediately and can introduce new categories at any time. However, a site can only downgrade or drop a given category's coverage after `max-age` seconds pass since the last header that committed to that category at the stronger mode.
 
 ### Preloading
 
@@ -126,11 +154,11 @@ As a general rule, websites SHOULD NOT request user-agents preload their WAICT s
 
 The details of how user-agent vendors are alerted to this are vendor-specific, but websites wishing user-agent vendors to preload MUST use an `Integrity-Policy-WAICT-v1` header with:
 
-* `mode` set to `enforce`.
+* Every category key specified in the standard is present and set to `enforce`.
 * `preload` set to `?1`.
 * `max-age` set to a value greater than or equal to 1 year (`31536000` seconds).
 
-User-agent vendors may configure user-agents with preload information via their vendor-specific out-of-band channels. Such user-agents SHOULD enforce WAICT as long as their vendor-supplied preload list is up to date.
+User-agent vendors MAY configure user-agents with preload information via their vendor-specific out-of-band channels. Such user-agents SHOULD enforce WAICT as long as their vendor-supplied preload list is up to date. User-agent support for preloading is optional.
 
 Vendors may choose different cutoffs for when they consider a preload list to be stale, but are RECOMMENDED to use a value of 30 days. That is, if a user-agent goes 30 days without receiving an updated preload list, it SHOULD stop enforcing entries on the preload list.
 
@@ -140,7 +168,7 @@ WAICT manifests provide a public commitment to the web application(s) being serv
 
 ## Fetching Manifests
 
-When a site is operating in `enforce` mode, network fetches for covered resources will be unable to complete successfully until a manifest is available. When a site is operating in `report` mode, network fetches for covered resources will be unable to complete successfully until a manifest is available or an implementation-defined timeout occurs. User-agents SHOULD fetch WAICT manifests with high priority as soon as they become aware of them.
+When a fetch for a resource is governed by a category in `enforce` mode, the fetch will be unable to complete successfully until a manifest is available. When the governing category is in `warn` or `report` mode, the fetch will be unable to complete successfully until a manifest is available or an implementation-defined timeout occurs. User-agents SHOULD fetch WAICT manifests with high priority as soon as they become aware of them.
 
 The manifest located at a given URL is expected to be immutable and SHOULD have its response set [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control) to include `immutable` and a long `max-age`. Sites can notify user-agents that an updated manifest is available by updating the `manifest` field of the WAICT header. User-agents only need to store the contents of one manifest per top-level origin at a time.
 
@@ -148,23 +176,26 @@ The response content type of a successful GET to a URL referenced in the `manife
 ```
 manifest | U+000A | transparency_proof | U+000A
 ```
-where `|` represents concatenation, `manifest` a UTF-8-encoded JSON object, and `transparency_proof` is a base64 encoding of the `WaictInclusionProof` specified in TODO, proving inclusion of `manifest` in a tree. Note the parsing of a response is unique, since `transparency_proof` cannot have a newline in it. The user-agent MUST reject a response that is invalid UTF-8, contains fewer than two U+000A codepoints, contains a `manifest` that is not valid JSON, or contains a `transparency_proof`.
+where `|` represents concatenation, `manifest` a UTF-8-encoded JSON object, and `transparency_proof` is a base64urlnopad encoding of the `WaictInclusionProof` specified in TODO, proving inclusion of `manifest` in a tree. Note the parsing of a response is unique, since `transparency_proof` cannot have a newline in it. The user-agent MUST reject a response that is invalid UTF-8, contains fewer than two U+000A codepoints, contains a `manifest` that is not valid JSON, or contains a `transparency_proof`.
 
-
-Servers SHOULD use a suitable compression scheme as negotiated by the user-agent.
+Servers SHOULD use a suitable HTTP compression scheme as negotiated by the user-agent. Support and use of [Compression Dictionary Transport](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Compression_dictionary_transport) is RECOMMENDED.
 
 ## Manifest Structure
 
 The integrity manifest is a JSON object with the following structure. All fields are mandatory unless marked optional:
 
-* `hashes` — a dictionary mapping URLs to hashes. All hashes MUST use the SHA-256 algorithm and be base64urlnopad-encoded.
+* `url_hashes` (optional) — a dictionary mapping URLs to hashes. All hashes MUST use the SHA-256 algorithm and be base64urlnopad-encoded.
 * `wasm_hashes` (optional) — a lexicographically sorted list of unique SHA-256 hashes (base64urlnopad) of permitted WebAssembly module bytes. The sorted order enables efficient membership testing by user-agents. See [Changes to WebAssembly Processing](#changes-to-webassembly-processing).
 * `fallback_hashes` (optional) - a lexicographically sorted list of unique SHA-256 hashes (base64urlnopad) of permitted content only for document navigation. The sorted order enables efficient membership testing by user-agents.
-* `wildcard_hashes` (optional) — a lexicographically sorted list of unique SHA-256 hashes (base64urlnopad-encoded). The sorted order enables efficient membership testing by user-agents.
+* `wildcard_hashes` (optional) — a lexicographically sorted list of unique SHA-256 hashes (base64urlnopad). The sorted order enables efficient membership testing by user-agents.
+* `inline_js_hashes` (optional) — a lexicographically sorted list of unique SHA-256 hashes (base64urlnopad) of permitted inline script element content and inline event-handler attribute values. The hash is computed over the same byte sequence that CSP3's [hash-source](https://www.w3.org/TR/CSP3/#grammardef-hash-source) check would hash. The sorted order enables efficient membership testing by user-agents. See [Inline Scripts, Styles, and Dynamic Code](#inline-scripts-styles-and-dynamic-code).
+* `eval_hashes` (optional) — a lexicographically sorted list of unique SHA-256 hashes (base64urlnopad) of permitted strings compiled as code through `eval`, `new Function`, and the string forms of `setTimeout` / `setInterval`. The sorted order enables efficient membership testing by user-agents. See [Inline Scripts and Dynamic Code](#inline-scripts-and-dynamic-code).
+* `inline_css_hashes` (optional) — a lexicographically sorted list of unique SHA-256 hashes (base64urlnopad) of permitted inline `<style>` element content and inline `style` attribute values, computed identically to `inline_js_hashes` but for styles. See [Inline Scripts, Styles, and Dynamic Code](#inline-scripts-styles-and-dynamic-code).
+* `inline_url_hashes` (optional) — a lexicographically sorted list of unique SHA-256 hashes (base64urlnopad) of permitted bytes addressed by `data:` or `blob:` URLs used as the source for active-class fetches. The sorted order enables efficient membership testing by user-agents. See [`data:` and `blob:` URLs as Active Content](#data-and-blob-urls-as-active-content).
 * `resource_delimiter` (optional) — a string used for splitting subresource contents.
 * `emergency_opt_out` (optional) — a boolean used when the origin needs to disable WAICT immediately. Default is `false`
 
-When a manifest has `emergency_opt_out = true`, we say it is a **tombstone**, since it is used to indicate that the origin has unenrolled from WAICT. No integrity checking happens when a tombstone manifest is active. For consistency, it is required that even tombstone manifests contain the mandatory fields.
+When a manifest has `emergency_opt_out = true`, we say it is a **tombstone**, since it is used to indicate that the origin has unenrolled from WAICT. No integrity checking happens when a tombstone manifest is served.
 
 > [!NOTE]
 > The `wildcard_hashes` and `resource_delimiter` fields may be removed if we can find a suitable alternative, e.g. using service workers to unbundle JS resources.
@@ -173,23 +204,35 @@ An example is given below:
 
 ```json
 {
-  "hashes": {
-    "/assets/x.html": "r4j9yW07mpTFSQ6ZRYOV0Au8Hfn2NqjqQMBqKL/SWCY=",
-    "https://my-fave-cdn.example/assets/css/main.css": "zet5ebcBGt1+fr6F0vJbpOv7p4tV/fIbFH4AafxtBl0=",
-    "/favicon.ico": "zbt5ebcBGt1+gr6F0vJbpOv7p4tV/fIbFH4AafxtBl0="
+  "url_hashes": {
+    "/assets/x.html": "r4j9yW07mpTFSQ6ZRYOV0Au8Hfn2NqjqQMBqKL_SWCY",
+    "https://my-fave-cdn.example/assets/css/main.css": "zet5ebcBGt1-fr6F0vJbpOv7p4tV_fIbFH4AafxtBl0",
+    "/favicon.ico": "zbt5ebcBGt1-gr6F0vJbpOv7p4tV_fIbFH4AafxtBl0"
   },
   "wasm_hashes": [
-    "Aq3rP9FkR8vLHnUGT5OgP7xmNyvDh2YcfJLmzgSEz7o=",
-    "kJ2E9N8C3vR5xP7yQwL4mFbA6dH0jT2uK9sG1nO3iVc="
+    "Aq3rP9FkR8vLHnUGT5OgP7xmNyvDh2YcfJLmzgSEz7o",
+    "kJ2E9N8C3vR5xP7yQwL4mFbA6dH0jT2uK9sG1nO3iVc"
   ],
   "fallback_hashes": [
-    "aB3xW9vKpL2mRnQy7dFtUeHsOiGjCzNw4kYuMlPqVrS=",
-    "tP8cE1hXwD5nJbAf6gQsIyKoZvLmRuN2eCdFpWxBqM0="
+    "aB3xW9vKpL2mRnQy7dFtUeHsOiGjCzNw4kYuMlPqVrS",
+    "tP8cE1hXwD5nJbAf6gQsIyKoZvLmRuN2eCdFpWxBqM0"
   ],
   "wildcard_hashes": [
-    "mVuswfW4XCBOWbx+QiKkPPQy+gTfr+i1sVADexgyN+8=",
-    "H9OJUrESfT3SUlRpqAiDFEvqnnG2Sp9/eloyVMqxnnb=",
-    "0SsmrVFFC7wxU4QM5UeZeXBnyKlXTAzfkVsZXIrzabo="
+    "0SsmrVFFC7wxU4QM5UeZeXBnyKlXTAzfkVsZXIrzabo",
+    "H9OJUrESfT3SUlRpqAiDFEvqnnG2Sp9_eloyVMqxnnb",
+    "mVuswfW4XCBOWbx-QiKkPPQy-gTfr-i1sVADexgyN-8"
+  ],
+  "inline_js_hashes": [
+    "9Yp1l4ZGmRkNvT7WdF3xJoYqUbLcEzKi5sHaDPnVrM4"
+  ],
+  "eval_hashes": [
+    "3Hp1l4ZGmRkNvT7WdF3xJoYqUbLcEzKi5sHaDPnVrM4"
+  ],
+  "inline_css_hashes": [
+    "fXpDmK2cYwBVL4qNeRTuJ6gAhSiOzCxIvHbZrUlNyP8"
+  ],
+  "inline_url_hashes": [
+    "qN7vR2eYwBVL4qNeRTuJ6gAhSiOzCxIvHbZrUlNyP8c"
   ],
   "resource_delimiter": "/* MY DELIM */"
 }
@@ -205,13 +248,31 @@ Manifests do not need to be validated in their entirety before they are used for
 
 Manifests MUST have the following properties:
 
-* If the manifest was linked to by a WAICT integrity policy header with nonzero `max-age` that is still in effect, then the transparency proof is successfully parsed and checked using the algorithm in TODO
-* All mandatory keys are present.
+* If the manifest was linked to by a WAICT integrity policy header with nonzero `max-age` that is still in effect, then the transparency proof is successfully parsed and checked using the algorithm in TODO (Reference Transparency Specifications)
 * If the manifest is non-tombstone:
-  * Values in `hashes`, `wasm_hashes`, and `wildcard_hashes` are valid base64urlnopad ([RFC   4648 Section 4](https://www.rfc-editor.org/rfc/rfc4648#section-4)) and decode to exactly 32   bytes.
-  * Each key `s` of `hashes` is a _canonical_ URL, defined as follows. `s` is parsed with the [API URL Parser](https://url.spec.whatwg.org/#api-url-parser) using the top-level origin (serialized as `scheme://host:port/`) as base URL (note, this permits external URLs; the base is only applied when the provided URL is relative), and any [fragment](https://url.spec.whatwg.org/#concept-url-fragment) is removed. The result is then [URL-serialized](https://url.spec.whatwg.org/#concept-url-serializer) with the *exclude fragment* flag set. `s` is canonical when this serialization equals `s`.
+  * Values in `url_hashes`, `wasm_hashes`, `fallback_hashes`, `wildcard_hashes`, `inline_js_hashes`, `inline_css_hashes`, `inline_url_hashes`, and `eval_hashes` are valid base64urlnopad ([RFC 4648 Section 5](https://www.rfc-editor.org/rfc/rfc4648#section-5)) and decode to exactly 32 bytes.
+  * Each key `s` of `url_hashes` is a _canonical_ URL, defined as follows. `s` is parsed with the [API URL Parser](https://url.spec.whatwg.org/#api-url-parser) using the top-level origin (serialized as `scheme://host:port/`) as base URL (note, this permits external URLs; the base is only applied when the provided URL is relative), and any [fragment](https://url.spec.whatwg.org/#concept-url-fragment) is removed. The result is then [URL-serialized](https://url.spec.whatwg.org/#concept-url-serializer) with the *exclude fragment* flag set. `s` is canonical when this serialization equals `s`.
 
-The first property above allows origins to keep WAICT transparency disabled by always setting the policy's `max-age` to 0, and serving an empty string (or any other newline-free string) as the transparency proof. Note the non-tombstone conditional means that manifests MUST be treated as tombstones even when the entries in all the fields are invalid.
+The first property above allows origins to keep WAICT transparency disabled by always setting the policy's `max-age` to 0, and serving an empty string (or any other newline-free string) as the transparency proof. Note the non-tombstone conditional means that manifests with `emergency_opt_out` set MUST be treated as tombstones even when the entries in all the fields are invalid.
+
+# Interactions with other Standards
+
+## Interaction with SRI and Integrity Policy
+
+[SRI](https://www.w3.org/TR/sri-2/) and [Integrity Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Integrity-Policy) are alternative sources of integrity metadata and policy rules for enforcing integrity. When handling a request which is covered by WAICT, the user agent MUST ignore any provided SRI metadata and any applicable integrity policy. This allows origins to offer support for all three standards simultaneously without requiring user-agents to hash resources multiple times or enter inconsistent enforcement states. WAICT deliberately uses the same type of integrity checks as SRI in order to allow the same codepaths to be used.
+
+> [!NOTE]
+> In the future, we may look to merge these specifications or rely on them explicitly.
+
+## Interaction with CSP
+
+[Content Security Policy (CSP3)](https://www.w3.org/TR/CSP3/) already provides directives that overlap with parts of WAICT's coverage: hash and nonce source expressions for integrity-style allowlisting (`'sha256-…'`, `'nonce-…'`), the `'unsafe-inline'` / `'unsafe-eval'` / `'wasm-unsafe-eval'` keywords for inline and dynamic code, and the `script-src`, `style-src`, `img-src`, etc. fetch directives for source-list enforcement. WAICT's category keys are named to parallel CSP's fetch directives; see the CSP analogue column in [Response Header](#response-header).
+
+The two specifications are intended to coexist. CSP source-list checks (host allowlists, scheme restrictions) continue to apply to covered fetches in their normal way. Where the two specifications would otherwise produce conflicting integrity decisions, the following rules apply:
+
+1. For a fetch covered by a WAICT category the user-agent MUST ignore any CSP hash source expression (`'sha256-…'`, `'sha384-…'`, `'sha512-…'`) and any matching nonce source on that fetch's destination directive. WAICT's manifest-based integrity check is authoritative for covered fetches.
+2. Several WAICT modes require the user-agent to behave as if specific CSP source expressions were absent from the origin's effective CSP, regardless of what the origin's CSP headers say. These source-expression removals are listed in [Inline Scripts, Styles, and Dynamic Code](#inline-scripts-styles-and-dynamic-code) (for `mode-inline-js` and `mode-inline-css`), in [`data:` and `blob:` URLs as Active Content](#data-and-blob-urls-as-active-content) (for active-class destination categories), and in [Changes to WebAssembly Processing](#changes-to-webassembly-processing) (for `mode-wasm`).
+3. For all other categories, the user-agent MAY treat WAICT's manifest as a logical conjunction with the origin's existing CSP fetch directive of the same destination: a fetch is permitted only if it passes both the CSP source-list check and the WAICT integrity check.
 
 # Changes to Network Fetches
 
@@ -219,45 +280,15 @@ This section describes how WAICT modifies the lifecycle of network fetches for c
 
 WAICT integrity checks apply to the unencoded response bytes delivered to the document, after any processing by [Service Workers](https://www.w3.org/TR/service-workers/). This is consistent with the behavior of [SRI](https://www.w3.org/TR/sri-2/).
 
+This section also covers two restrictions imposed by the destination categories on content that does not traverse the network: [`data:` and `blob:` URLs as Active Content](#data-and-blob-urls-as-active-content), in which the URL is fetched but its bytes are supplied inline; and [`srcdoc` Iframes](#srcdoc-iframes), in which an inline attribute supplies the iframe's document. These restrictions are governed by the same `mode-*` keys as the corresponding network fetches.
+
 ## Determine Coverage
 
-Before [`fetch`](https://fetch.spec.whatwg.org/#concept-fetch) is invoked, the user-agent determines whether the request is covered by the WAICT policy by checking the [request](https://fetch.spec.whatwg.org/#concept-request)'s [`destination`](https://fetch.spec.whatwg.org/#concept-request-destination).
+Before [`fetch`](https://fetch.spec.whatwg.org/#concept-fetch) is invoked, the user-agent determines whether the request is covered by the WAICT policy by checking the [request](https://fetch.spec.whatwg.org/#concept-request)'s [`destination`](https://fetch.spec.whatwg.org/#concept-request-destination) and mapping it to a category using the **Destinations** column of the category table in [Response Header](#response-header). Each covered destination belongs to exactly one category.
 
-The following destination types are covered by WAICT as **active content**:
+Categories are partitioned into **active content** (a covered fetch whose URL is missing from the manifest fails) and **passive content** (a covered fetch whose URL is missing from the manifest skips integrity checking and proceeds). The class of a category is fixed by this specification; operators control only the strictness of the corresponding `mode-*` key.
 
- * document
- * frame
- * iframe
- * audioworklet
- * paintworklet
- * script
- * serviceworker
- * sharedworker
- * worker
- * style
- * xslt
- * object
-
-> [!NOTE]
-> Should we treat html as passive content to enable server-generated HTML to coexist with web apps on the same domain?
-
-The following destination types are covered by WAICT as **passive content**:
-
-* audio
-* font
-* image
-* json
-* video
-
-If the destination does not appear in the above lists, the fetch proceeds without WAICT processing.
-Otherwise, the fetch is subject to the integrity checks described below.
-
-### Interaction with SRI and Integrity Policy
-
-[SRI](https://www.w3.org/TR/sri-2/) and [Integrity Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Integrity-Policy) are alternative sources of integrity metadata and policy rules for enforcing integrity. When handling a request which is covered by WAICT, the user agent MUST ignore any provided SRI metadata and any applicable integrity policy. This allows origins to offer support for all three standards simultaneously without requiring user-agents to hash resources multiple times or enter inconsistent enforcement states.
-
-> [!NOTE]
-> In the future, we may look to merge these specifications or rely on them explicitly.
+A request is **covered** by WAICT if its destination is listed for some category in that table and the stored WAICT state for the top-level origin contains a record for that category. Otherwise the fetch proceeds without WAICT processing. Covered fetches are subject to the integrity checks described below, governed by the mode of the mapped category.
 
 ## Request Setup
 
@@ -279,25 +310,26 @@ After [`main fetch`](https://fetch.spec.whatwg.org/#concept-main-fetch) dispatch
 
 The existing `main fetch` algorithm already handles [SRI integrity checking](https://w3c.github.io/webappsec-subresource-integrity/#does-response-match-metadatalist) when a request's [integrity metadata](https://fetch.spec.whatwg.org/#concept-request-integrity-metadata) is nonempty: the response body is [fully read](https://fetch.spec.whatwg.org/#body-fully-read), checked against the metadata, and only then passed to `fetch response handover`. WAICT extends this step to also cover the case where integrity metadata comes from a manifest rather than an inline attribute.
 
-The response body is [fully read](https://fetch.spec.whatwg.org/#body-fully-read), the user-agent hashes the content, and checks if it is in the manifest. For active content, the fetched URL is required to have an entry in the manifest. For passive content, the fetched URL may not appear in the manifest, in which case integrity checking is skipped. More precisely, to perform integrity checking on the fetch, the user-agent proceeds as follows:
+The response body is [fully read](https://fetch.spec.whatwg.org/#body-fully-read), the user-agent hashes the content, and checks if it is in the manifest. For a request whose category is in the **active** class, the fetched URL is required to have an entry in the manifest. For a request whose category is in the **passive** class, the fetched URL may be absent from the manifest, in which case integrity checking is skipped. More precisely, to perform integrity checking on the fetch, the user-agent proceeds as follows:
 
+1. Let `cat` be the category the request maps to, per [Determine Coverage](#determine-coverage), and let `class` be that category's active/passive class.
 1. Wait for the manifest to be available. If the manifest cannot be fetched within an implementation-defined timeout, fail with reason `manifest_unavailable`.
 1. If the manifest has failed validation (described above), the user-agent fails with reason `invalid_manifest`.
 1. If the manifest is a tombstone, return success.
 1. Let `reqURL` be the request's [URL](https://fetch.spec.whatwg.org/#concept-request-url) as it was at the time [`fetch`](https://fetch.spec.whatwg.org/#concept-fetch) was invoked, prior to any redirects. Let `reqKey` be the [URL serialization](https://url.spec.whatwg.org/#concept-url-serializer) of `reqURL` with the *exclude fragment* flag set.
 1. Let `b` be the bytes of the response body and `h` be the base64urlnopad-encoded SHA-256 hash of `b`.
-1. Let `pathHash` be the hash value from `manifest["hashes"]` whose key's canonical form (as defined in [Validating Manifests](#validating-manifests)) equals `reqKey`, or `undefined` if no such entry exists.
-1. If the destination type is listed under **passive content** and `pathHash` is undefined, return success.
+1. Let `pathHash` be the hash value from `manifest["url_hashes"]` whose key's canonical form (as defined in [Validating Manifests](#validating-manifests)) equals `reqKey`, or `undefined` if no such entry exists.
+1. If `class` is **passive** and `pathHash` is undefined, return success.
 1. Let `fallbackHashes` be `manifest["fallback_hashes"]`, or undefined if not present.
-1. If `fallbackHashes` is defined and non-empty, and the request destination is `document`, check whether `h` is a member of `fallbackHashes`. If it is, return success.
+1. If `fallbackHashes` is defined and non-empty, and `cat` is `mode-document`, check whether `h` is a member of `fallbackHashes`. If it is, return success.
 1. Let `wildcardHashes = manifest["wildcard_hashes"]`, or `undefined` if not present.
-1. If `pathHash` is defined, compare `h` to `pathHash`. If they match, return success. Otherwise, fail with reason `no_manifest_match`. A resource whose URL appears in `hashes` MUST match via its `pathHash`; the wildcard check is never used as a fallback.
+1. If `pathHash` is defined, compare `h` to `pathHash`. If they match, return success. Otherwise, fail with reason `no_manifest_match`. A resource whose URL appears in `url_hashes` MUST match via its `pathHash`; the wildcard check is never used as a fallback.
 1. If `wildcardHashes` is defined and non-empty and `resource_delimiter` is defined and non-empty:
     1. Let `d` be `resource_delimiter`.
     1. For each component `b_i` of `b`, compute `SHA-256(b_i)`, base64urlnopad-encode it, and check whether the result is a member of `wildcardHashes`. If all components match, return success. Otherwise, fail with reason `no_manifest_match`.
 1. Fail with reason `missing_from_manifest`.
 
-If the integrity check succeeds, `main fetch` proceeds to [`fetch response handover`](https://fetch.spec.whatwg.org/#fetch-finale) with the verified response. If it fails, the behavior depends on the WAICT mode as described in [Handling Failures](#handling-failures).
+If the integrity check succeeds, `main fetch` proceeds to [`fetch response handover`](https://fetch.spec.whatwg.org/#fetch-finale) with the verified response. If it fails, the behavior depends on the mode of `cat` as described in [Handling Failures](#handling-failures).
 
 ### Manifest Override on Subresource Responses
 
@@ -314,37 +346,29 @@ Some user-agents begin processing responses before they are complete, for exampl
 > [!NOTE]
 > This is intended to enable user-agents to engage in unobservable actions like speculatively fetching subresources from unverified responses which are critical for performance, provided those actions can't be used to bypass integrity checks.
 
-## Handling Failures
+## `data:` and `blob:` URLs as Active Content
 
-When an integrity check fails, the user-agent MUST take the following actions.
+A `data:` or `blob:` URL embeds content that did not traverse the network. The URL itself is not stable across deployments and cannot be looked up in the manifest by URL, but the bytes it addresses can still be hashed and checked against a manifest-supplied allowlist. Operators that need to permit specific opaque-URL content list its SHA-256 hash in the manifest field `inline_url_hashes` (see [Manifest Structure](#manifest-structure)). Because the manifest is publicly logged via WAICT transparency, an attacker compromising only the server cannot add new entries undetectably.
 
-### Reporting
+When a fetch's destination maps to a category in the **active** class (see [Determine Coverage](#determine-coverage)) and that category is in `enforce` or `warn` mode, the user-agent MUST behave as if the `data:` and `blob:` scheme source expressions were absent from the corresponding CSP fetch directive, with one exception: if `manifest["inline_url_hashes"]` is present and the base64urlnopad-encoded SHA-256 hash of the URL's resolved bytes is a member of it, the user-agent MUST treat the corresponding scheme source expression as present for that fetch. The resolved bytes are:
 
-In both `report` and `enforce` modes, the user-agent MUST:
+* for a `data:` URL, the decoded payload (the bytes following the comma, with base64 decoding applied if the `base64` extension is present);
+* for a `blob:` URL, the bytes of the `Blob` object the URL resolves to at the time of the fetch.
 
-* Log the failure to the browser console and developer tools.
-* If `endpoints` is non-empty, report the error as a `waict-violation` to the specified endpoints following the [Reporting API](https://developer.mozilla.org/en-US/docs/Web/API/Reporting_API).
+If `inline_url_hashes` is absent or the bytes do not match any entry, the fetch is blocked by the CSP source-list check as described above. Examples of fetches that without a matching `inline_url_hashes` entry would be blocked by this rule:
 
-The `waict-violation` report `body` includes the keys and values from [IntegrityViolationReportBody](https://developer.mozilla.org/en-US/docs/Web/API/IntegrityViolationReportBody), enriched with an entry `reason` indicating the cause of the failure:
+* `<script src="data:…">` / `<script src="blob:…">` — under `mode-script`.
+* `<iframe src="data:text/html,…">` / `<iframe src="blob:…">` — under `mode-frame`.
+* `<object data="data:…">` — under `mode-object`.
+* A `data:` or `blob:` URL passed to a worker constructor — under `mode-worker`.
 
-* `manifest_unavailable` — The manifest for the origin could not be loaded.
-* `invalid_manifest` — The manifest was loaded, but was malformed, had unexpected types, or was missing required fields (including `transparency_proof`).
-* `invalid_transparency_proof` — A manifest and transparency proof were provided, but the proof could not be parsed.
-* `missing_from_manifest` — A valid manifest was available, but this resource was not covered.
-* `no_manifest_match` — A valid manifest was available and described this resource, but the resource did not match the manifest entry.
+Passive-class categories (`mode-image`, `mode-font`, `mode-media`) do not impose this restriction; `data:` and `blob:` URLs for those destinations remain subject to the origin's own CSP, and `inline_url_hashes` is not consulted.
 
-### Report Mode
+## `srcdoc` Iframes
 
-In `report` mode, the user-agent MUST still load the resource. Report mode is intended for web developers to validate their deployment; it does not provide security for user-agents.
+When `mode-frame` is set to `enforce` or `warn`, the user-agent MUST block use of the [`srcdoc`](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-srcdoc) attribute on `<iframe>` elements. The `srcdoc` attribute embeds an entire HTML document — including any scripts, styles, and other resources defined inline within it — in the attribute value, bypassing both the network and the manifest. CSP does not provide a source expression for `srcdoc`, so this restriction is enforced directly by the user-agent rather than as a source-expression removal.
 
-Compliant user-agents SHALL NOT display error messages to end-users who have not indicated they wish to see additional technical information.
-
-### Enforce Mode
-
-In `enforce` mode, the behavior depends on the failure type:
-
-* `manifest_unavailable`, `invalid_manifest`, `invalid_transparency_proof` - the user-agent MUST display a warning page to the user indicating the error. The user-agent SHOULD NOT allow the user to bypass the warning.
-* `missing_from_manifest`, `no_manifest_match` - The user-agent MUST return an appropriate [network error](https://fetch.spec.whatwg.org/#concept-network-error) for the fetch.
+When `mode-frame` is set to `report`, the user-agent MUST permit the `srcdoc` document to load and MUST report the violation as an `inline_violation` against `mode-frame` (see [Handling Failures](#handling-failures)).
 
 # Changes to WebAssembly Processing
 
@@ -368,27 +392,113 @@ WebAssembly defines the [`HostEnsureCanCompileWasmBytes()`](https://webassembly.
 
 When WAICT is active for the current top-level origin, the user-agent MUST execute the following steps within `HostEnsureCanCompileWasmBytes(bytes)`:
 
-1. If no WAICT state is stored for this top-level origin, return normally (compilation is not blocked by WAICT).
-1. Wait for the manifest to be available. If the manifest cannot be fetched within an implementation-defined timeout, proceed to step 5 with reason `manifest_unavailable`.
-1. If the manifest has failed validation, proceed to step 5 with reason `invalid_manifest`.
-1. If the manifest is a tombstone, return success.
-1. Let `h` be the base64nopad-encoded SHA-256 hash of `bytes`. Let `wasmHashes` be `manifest["wasm_hashes"]`, or an empty list if not present. If `h` is a member of `wasmHashes`, return normally (compilation is permitted).
-1. The integrity check has failed. Let the failure reason be `wasm_hash_mismatch` unless set otherwise in step 2 or 3. The user-agent MUST report the failure as described in [Reporting](#reporting). If the WAICT mode is `enforce`, the user-agent MUST throw a `WebAssembly.CompileError`. If the WAICT mode is `report`, compilation proceeds normally.
+1. If no WAICT state is stored for this top-level origin, or if no record exists for the `mode-wasm` category, return normally (compilation is not blocked by WAICT).
+1. Resolve the manifest as in steps 2–4 of [Integrity Check](#integrity-check): wait for the manifest with an implementation-defined timeout (`manifest_unavailable` on timeout), reject invalid manifests (`invalid_manifest`), and treat tombstones as success.
+1. Let `h` be the base64urlnopad-encoded SHA-256 hash of `bytes`. If `manifest["wasm_hashes"]` is present and `h` is a member of it, return normally (compilation is permitted). Otherwise, the failure reason is `wasm_hash_mismatch` (or the manifest reason from the previous step).
+1. Handle the failure under the mode of `mode-wasm` as described in [Handling Failures](#handling-failures). In `warn` mode the user-agent MAY perform this hash check asynchronously without blocking compilation, surfacing the warning UX once the failure is observed.
 
-# Inline Content and Dynamic Code Restrictions
+# Inline Scripts, Styles, and Dynamic Code
 
-> [!NOTE]
-> It is not yet clear which restrictions make sense. There is a tension between preventing devs from accidentally escaping transparency, and allowing devs to make the sites that they want. Tracking issue [here](https://github.com/waict-wg/waict-integrity-spec/issues/46) and more discussion [here](https://github.com/waict-wg/waict-integrity-spec/pull/53).
+WAICT's fetch-based integrity check covers resources loaded from the network, but inline `<script>` and `<style>` content, dynamic code compiled from strings, and `javascript:` URIs bypass network fetches entirely. The content delivered by these paths is not known at build time, so it cannot appear in the manifest by URL and cannot be checked against it.
+
+WAICT addresses these paths through additional restrictions whose strictness is controlled by the mode keys `mode-inline-js` and `mode-inline-css` defined in [Response Header](#response-header). Where possible, each restriction is expressed by removing specific source expressions from the origin's effective CSP, so that user-agents can reuse the existing CSP enforcement code paths rather than introduce parallel ones.
+
+These restrictions are **additive** to any CSP the origin delivers: the user-agent enforces both. An origin's CSP can further constrain behavior but cannot relax these restrictions. Because WAICT's threat model treats the server as untrusted, the WAICT-side restrictions apply regardless of what the server's CSP headers say.
+
+CSP's nonce-source, hash-source, and eval-hash-source allowlisting mechanisms (`'nonce-…'`, `'sha256-…'`, `'sha384-…'`, `'sha512-…'`, `'eval-sha256-…'`, `'eval-sha384-…'`, `'eval-sha512-…'`) cannot be used to permit specific inline scripts, styles, or dynamic code under WAICT. A server that can deliver malicious inline content can equally deliver the matching nonce or hash that would allowlist it, so the CSP-supplied allowlist provides no integrity guarantee against an untrusted server. This parallels the treatment of nonce- and hash-sources for covered fetches in [Interaction with CSP](#interaction-with-csp).
+
+In its place, the manifest carries the trusted allowlist: operators that need to permit specific inline scripts, styles, or dynamic code list their SHA-256 hashes in the manifest fields `inline_js_hashes`, `inline_css_hashes`, and `eval_hashes` (see [Manifest Structure](#manifest-structure)). Because the manifest is publicly logged via WAICT transparency, an attacker compromising only the server cannot add new entries undetectably.
+
+## Inline Scripts and Dynamic Code
+
+When `mode-inline-js` is set to `enforce` or `warn`, the user-agent MUST behave as if the origin's effective `script-src` directive contained none of: `'unsafe-inline'`, `'unsafe-eval'`, any CSP-supplied nonce-source expression (`'nonce-…'`), any CSP-supplied hash-source expression (`'sha256-…'`, `'sha384-…'`, `'sha512-…'`), or any CSP-supplied eval-hash source expression (`'eval-sha256-…'`, `'eval-sha384-…'`, `'eval-sha512-…'`; see [script-src-v2](https://github.com/explainers-by-googlers/script-src-v2)). The user-agent MUST additionally treat the effective `script-src` as containing a SHA-256 hash-source for every entry in `manifest["inline_js_hashes"]`, if that field is present, and a SHA-256 eval-hash source for every entry in `manifest["eval_hashes"]`, if that field is present. The user-agent applies this by running the standard CSP3 algorithms (extended by script-src-v2 for the eval-hash source) against the modified effective `script-src`:
+
+* The ["Should element's inline type behavior be blocked?"](https://www.w3.org/TR/CSP3/#should-block-inline) algorithm for types `"script"` and `"script attribute"` — blocking inline `<script>` elements and inline event-handler attributes (e.g., `onclick`, `onload`, `onerror`), except when the SHA-256 hash of the element's content (or attribute value), computed per CSP3, appears in `manifest["inline_js_hashes"]`. A `nonce` attribute or a CSP-supplied hash-source never permits execution under WAICT; only manifest-listed hashes do.
+* The [`EnsureCSPDoesNotBlockStringCompilation`](https://www.w3.org/TR/CSP3/#can-compile-strings) integration point (as extended by script-src-v2 to consult eval-hash sources) — blocking `eval(string)`, `new Function(string)`, `setTimeout(string, …)`, `setInterval(string, …)`, and any other API that compiles a string as script, including `Function.prototype.constructor` invoked with a string body, except when the SHA-256 hash of the compiled string (computed per script-src-v2) appears in `manifest["eval_hashes"]`. A CSP-supplied `'eval-sha…-…'` source never permits compilation under WAICT; only manifest-listed hashes do.
+
+Navigation to a `javascript:` URI is also gated on `mode-inline-js`, since CSP3 treats it as inline-script execution. When `mode-inline-js` is `enforce` or `warn`, the user-agent MUST block navigation to a `javascript:` URI unless the [`userInvolvement`](https://html.spec.whatwg.org/multipage/browsing-the-web.html#beginning-navigation) is `"Browser UI"`. The manifest provides no allowlist for `javascript:` URIs; CSP3 has no hash mechanism for them. The Browser-UI carve-out preserves JavaScript bookmarklets while blocking page-triggered navigation.
+
+The source-expression removals and manifest hash-source additions described above apply equally to any `script-src-elem` and `script-src-attr` directives the origin's CSP delivers. CSP3 derives these from `script-src` when they are not explicitly set, and the `"Should element's inline type behavior be blocked?"` algorithm consults the appropriate derived directive for each check (`script-src-elem` for element content, `script-src-attr` for attribute values). The same rules apply uniformly to classic scripts, module scripts, and importmaps.
+
+CSP3's hash-source matching applies to inline `<script>` element content by default, but applies to inline event-handler attribute values only when `'unsafe-hashes'` is present. For the purpose of matching against `manifest["inline_js_hashes"]`, the manifest-supplied hash-sources are treated as if `'unsafe-hashes'` were also present, so that a single entry in `inline_js_hashes` permits both an inline `<script>` element and an inline event-handler attribute with the same content bytes. This extension applies only to manifest-listed hashes; CSP-supplied hash-sources continue to be removed as described above.
+
+When matching against `manifest["inline_js_hashes"]` or `manifest["eval_hashes"]`, the user-agent SHOULD compare the SHA-256 byte sequences directly rather than re-encoding the manifest's base64urlnopad value into CSP's base64 hash-source serialization.
+
+## Inline Styles
+
+When `mode-inline-css` is set to `enforce` or `warn`, the user-agent MUST behave as if the origin's effective `style-src` directive contained none of: `'unsafe-inline'`, any CSP-supplied nonce-source expression, or any CSP-supplied hash-source expression. The user-agent MUST additionally treat the effective `style-src` as containing a SHA-256 hash-source for every entry in `manifest["inline_css_hashes"]`, if that field is present.
+
+The user-agent applies this by running the standard CSP3 ["Should element's inline type behavior be blocked?"](https://www.w3.org/TR/CSP3/#should-block-inline) algorithm for types `"style"` and `"style attribute"` against the modified effective `style-src`. Inline `<style>` elements and inline `style` attributes are blocked, except when the SHA-256 hash of the element's content (or attribute value) appears in `manifest["inline_css_hashes"]`. A `nonce` attribute or a CSP-supplied hash-source never permits execution under WAICT; only manifest-listed hashes do.
+
+The source-expression removals and manifest hash-source additions described above apply equally to any `style-src-elem` and `style-src-attr` directives the origin's CSP delivers. CSP3 derives these from `style-src` when they are not explicitly set, and the algorithm consults the appropriate derived directive for each check (`style-src-elem` for `<style>` element content, `style-src-attr` for `style` attribute values).
+
+CSP3's hash-source matching applies to inline `<style>` element content but does not natively apply to inline `style` attribute values (CSP3 requires `'unsafe-hashes'` for the latter). For the purpose of matching against `manifest["inline_css_hashes"]`, the manifest-supplied hash-sources are treated as if `'unsafe-hashes'` were also present, so that a single entry in `inline_css_hashes` permits both an inline `<style>` element and an inline `style` attribute with the same content bytes. The hash is computed over the same byte sequence that CSP3's hash-source check would hash for an inline `<style>` element; for a `style` attribute, the hash is computed over the attribute value's bytes (UTF-8 encoded). This extension applies only to manifest-listed hashes; CSP-supplied hash-sources continue to be removed as described above.
+
+As with `inline_js_hashes`, the user-agent SHOULD compare SHA-256 byte sequences directly rather than re-encoding through CSP's base64 hash-source serialization.
+
+## Failure Handling
+
+Violations of the restrictions in this section are reported as `inline_violation` and handled under the mode of the governing key (`mode-inline-js` or `mode-inline-css`). See [Handling Failures](#handling-failures).
+
+# Handling Failures
+
+When a WAICT check fails, the user-agent's response is governed by the mode of the category that triggered the check. Manifest-level failure reasons (`manifest_unavailable`, `invalid_manifest`, `invalid_transparency_proof`) are attributed to the category whose check could not proceed; if multiple categories were waiting on the same manifest, each treats the failure under its own mode.
+
+## Reporting
+
+In `report`, `warn`, and `enforce` modes, the user-agent MUST:
+
+* Log the failure to the browser console and developer tools.
+* If `report-to` is non-empty, report the error as a `waict-violation` to the specified endpoints following the [Reporting API](https://developer.mozilla.org/en-US/docs/Web/API/Reporting_API).
+
+The `waict-violation` report `body` includes the keys and values from [IntegrityViolationReportBody](https://developer.mozilla.org/en-US/docs/Web/API/IntegrityViolationReportBody), enriched with the following entries (named to parallel the fields in CSP's [`csp-violation` report body](https://www.w3.org/TR/CSP3/#reporting)):
+
+* `reason` — the cause of the failure (see list below).
+* `disposition` — the mode under which the failure was handled. One of `enforce`, `warn`, or `report`. Equivalent to the `disposition` field on a `csp-violation` report.
+* `effectiveDirective` — the category key that triggered the failure, e.g. `mode-script`, `mode-wasm`. Parallels the `effectiveDirective` field on a `csp-violation` report.
+
+The `reason` entry takes one of the following values:
+
+* `manifest_unavailable` — The manifest for the origin could not be loaded.
+* `invalid_manifest` — The manifest was loaded, but was malformed, had unexpected types, or was missing required fields (including `transparency_proof`).
+* `invalid_transparency_proof` — A manifest and transparency proof were provided, but the proof could not be parsed.
+* `missing_from_manifest` — A valid manifest was available, but this resource was not covered.
+* `no_manifest_match` — A valid manifest was available and described this resource, but the resource did not match the manifest entry.
+* `wasm_hash_mismatch` — A WebAssembly module's bytes did not match any hash in `wasm_hashes`.
+* `inline_violation` — An inline script, inline style, dynamic-code path, `javascript:` URI, `data:` or `blob:` URL, or `srcdoc` iframe violated its governing category's restriction.
+
+For an `inline_violation`, the `effectiveDirective` is the governing mode key: `mode-inline-js` for inline scripts, dynamic code, and `javascript:` URIs; `mode-inline-css` for inline styles; the destination's active-class category (e.g., `mode-script`, `mode-frame`, `mode-object`, `mode-worker`) for `data:` and `blob:` URLs; and `mode-frame` for `srcdoc`.
+
+## Report Mode
+
+In `report` mode, the user-agent MUST permit the operation (load the resource, permit WebAssembly compilation, execute the inline behavior, or load the `srcdoc` document). Report mode is intended for web developers to validate their deployment; it does not provide security for user-agents.
+
+Compliant user-agents SHALL NOT display error messages to end-users who have not indicated they wish to see additional technical information.
+
+## Warn Mode
+
+In `warn` mode, the user-agent MUST permit the operation, and any integrity check MAY proceed asynchronously. The user-agent SHOULD NOT delay [`fetch response handover`](https://fetch.spec.whatwg.org/#fetch-finale), WebAssembly compilation, or inline execution while waiting for a `warn`-mode check to complete.
+
+If a `warn`-mode check ultimately fails, the user-agent MUST surface a user-visible indication that the top-level origin failed a WAICT integrity check. The form of this indication is implementation-defined (for example, a security indicator change in the address bar), but it MUST be distinguishable from the indication shown when no WAICT failure has occurred. The user-agent SHOULD NOT block the user from continuing to interact with the page.
+
+## Enforce Mode
+
+In `enforce` mode, the user-agent MUST prevent the violating behavior. The exact form depends on the failure type:
+
+* `manifest_unavailable`, `invalid_manifest`, `invalid_transparency_proof` — display a warning page to the user indicating the error. The user-agent SHOULD NOT allow the user to bypass the warning.
+* `missing_from_manifest`, `no_manifest_match` — return an appropriate [network error](https://fetch.spec.whatwg.org/#concept-network-error) for the fetch.
+* `wasm_hash_mismatch` — throw a `WebAssembly.CompileError`, as described in [Changes to WebAssembly Processing](#changes-to-webassembly-processing).
+* `inline_violation` — block the inline behavior: do not execute the inline script or style, do not compile the dynamic-code string, do not navigate the `javascript:` URI, do not fetch the `data:` or `blob:` URL, and do not load the `srcdoc` document. For `data:` and `blob:` URLs, the blocking is performed by the CSP source-list check after WAICT removes the scheme source expression (see [`data:` and `blob:` URLs as Active Content](#data-and-blob-urls-as-active-content)).
 
 # Non-Normative Appendices
 
 ## Server Operator Advice
 
-Server operators should be cautious when deploying WAICT enforcement. In general, there is no recourse for a faulty deployment in `enforce` mode, other than waiting out the `max-age` period. In the event of a faulty deployment and the use of `preload`, the waiting-out period is potentially unbounded.
+Server operators should be cautious when deploying WAICT enforcement. In general, there is no recourse for a faulty deployment of a category in `enforce` mode, other than waiting out the `max-age` period. In the event of a faulty deployment and the use of `preload`, the waiting-out period is potentially unbounded.
 
-Server operators are recommended to deploy WAICT in `report` mode initially and gain confidence in their deployment gradually. Server operators should treat reported errors seriously. Every reported error will result in a broken user-agent if `enforce` is enabled.
+Server operators are recommended to deploy each category in `report` mode initially and gain confidence in their deployment gradually. Every reported error will result in a broken user-agent if that category is later moved to `enforce`, so reported errors should be treated seriously. `warn` mode is available as an optional intermediate step that gathers end-user feedback at the cost of a security indicator change.
 
-Once a server operator has become confident in their use of `report` mode, they should consider switching to `enforce` mode with a low `max-age`, e.g. on the order of minutes. As time passes, server operators should consider raising the `max-age`.
+Once an operator is confident in a category's behavior, they should consider switching it to `enforce` mode with a low `max-age` (e.g. minutes) and raising the `max-age` over time. Different categories may be at different points in this rollout simultaneously — for example, `mode-script=enforce` while `mode-wasm=warn`.
 
 The exact age that server operators settle on is a tradeoff between the maximum recovery time for their site and how often users are expected to visit their site and still need a security benefit.
 
@@ -406,6 +516,14 @@ In practice, operators need only ensure that any response carrying a WAICT heade
 
 When publishing a new version of the application, the new resources can be associated with the new manifest.
 
+## Future Extensions to the Specification
+
+As user-agents introduce new ways to load active content, WAICT can be extended to cover them by defining additional categories. This is backwards compatible: a new category provides no coverage until a site opts in by setting its mode, so existing deployments are unaffected.
+
+Tightening an existing category is more constrained. Once sites rely on a mode's semantics, silently changing its behavior risks breaking deployments, which is unacceptable. Additional checks must therefore be introduced either as a new category that sites explicitly enable, or as a new version of WAICT with revised semantics for the existing mode.
+
+This approach favours availability over security: sites seeking the strongest guarantees will need to track changes to the specification and adopt new categories or versions as they are defined. New means of executing active content are a relatively infrequent change to the web platform, so this burden is expected to remain low.
+
 ## Security Considerations
 
 This design emulates that of RFC 6797 (HSTS).
@@ -416,15 +534,13 @@ As a consequence, this design ensures that websites continue to maintain availab
 
 The use of the `Integrity-Policy-WAICT-v1` header is essential for the overall security of WAICT. User-agents must be aware of the need to enforce WAICT in order to gain security benefits from it.
 
-User-agents only gain a security benefit from the use of `enforce` mode. User-agents do not gain a security benefit from the use of `report` mode.
+User-agents only gain a cryptographic security benefit from categories set to `enforce` mode. Because each category is ratcheted independently, a site may simultaneously offer strong guarantees in one category (e.g. `mode-script=enforce`) while still iterating in another (e.g. `mode-wasm=warn`); user-agents must not assume that a single category in `enforce` mode implies enforcement of others.
 
 WAICT V1 forces the use of SHA256 for hashing, unlike SRI which supports a family of hash functions. Using a fixed hash function is necessary to enable user-agents to begin hashing integrity-checked resources before a manifest is available (and so preserve existing website performance). If the security of SHA256 is called into question by future cryptologic advances, a new version of WAICT will need to be defined with a new hash function.
 
 ### Cross-origin iframes
 
-WAICT does not extend integrity enforcement into cross-origin iframes. A same-origin iframe is effectively part of the top-level application — it shares the same origin, can access the parent's DOM, cookies, and storage, and can execute code with the full privileges of that origin. A compromised same-origin iframe is therefore equivalent to a compromise of the top-level page itself, so WAICT must cover it.
-
-A cross-origin iframe, by contrast, is isolated by the browser's same-origin policy. It cannot read or write the embedding page's DOM or storage, and its requests carry its own origin's credentials rather than the embedder's. This allows sites to effectively embed untrusted third-party content.
+The Scope rule covers same-origin iframes but not cross-origin ones. A same-origin iframe shares the embedder's DOM, cookies, and storage, and can execute code with the full privileges of the top-level origin — a compromise there is a compromise of the embedding page, so WAICT must cover it. A cross-origin iframe is isolated by the same-origin policy and may host untrusted third-party content, so the embedder's WAICT policy does not extend into it.
 
 ### Fingerprinting
 


### PR DESCRIPTION
Replaces the single on/off enforcement model with a set of per-category
mode keys (mode-document, mode-script, mode-style, mode-frame,
mode-object, mode-worker, mode-image, mode-font, mode-media, mode-wasm,
mode-inline-js, mode-inline-css), each taking a report / warn / enforce
strictness. Each category ratchets independently and carries its own
max-age, so origins can phase categories in at different speeds without
losing downgrade protection on the ones already deployed.
Addresses https://github.com/waict-wg/waict-integrity-spec/issues/55.

Expresses WAICT's inline-content, dynamic-code, WebAssembly, and
opaque-URL restrictions as targeted modifications to the origin's
effective CSP rather than as parallel enforcement paths. The user-agent
removes specific source expressions ('unsafe-inline', 'unsafe-eval',
'wasm-unsafe-eval', CSP-supplied nonces and hashes, data:/blob: scheme
sources on active destinations) and injects manifest-listed hash-sources
in their place, so existing CSP code paths do the work.
Addresses https://github.com/waict-wg/waict-integrity-spec/issues/46.

Adds manifest fields that carry the trusted allowlists for content the
network-fetch check cannot cover: inline_js_hashes and inline_css_hashes
for inline scripts and styles, eval_hashes for strings compiled via
eval / new Function / setTimeout / setInterval (paired with the
eval-hash source from script-src-v2), and inline_url_hashes for the
decoded bytes behind data: and blob: URLs used as active content.
Renames the original hashes field to url_hashes and makes it optional.
Because the manifest is transparency-logged, these allowlists are
trustworthy in a way that CSP-supplied nonces and hashes (which the
untrusted server also delivers) are not.
Addresses https://github.com/waict-wg/waict-integrity-spec/issues/46.

Add a Warn mode which doesn't block loads but does result in UX.
Addresses https://github.com/waict-wg/waict-integrity-spec/issues/56.

Allows manifests on sub-resources.
Addresses https://github.com/waict-wg/waict-integrity-spec/issues/51.